### PR TITLE
Fixed a bug related to math environment

### DIFF
--- a/ch3LyX.lyx
+++ b/ch3LyX.lyx
@@ -107,6 +107,18 @@ Tez çalışması kapsamında sismik yalıtımlı yapıların doğrusal olmayan 
  için hazırlanan örnek sistemler incelenecektir.
 \end_layout
 
+\begin_layout Standard
+Numarasız denkleme örnek:
+\begin_inset Formula 
+\[
+\Delta=5x
+\]
+
+\end_inset
+
+
+\end_layout
+
 \begin_layout Section
 İncelenen Yapıların Özellikleri
 \end_layout

--- a/defsLyX.tex
+++ b/defsLyX.tex
@@ -33,39 +33,39 @@
 %\renewcommand{\theequation}{{\bf\arabic{chapter}.\arabic{equation}}}
 %%%%\renewcommand{\thefootnote}{\hskip \arabic{footnote}}
 
-\def\be{\begin{equation}} %
-\def\ee{\end{equation}}%
-\def\beq{\begin{eqnarray}}%
-\def\eeq{\end{eqnarray}}%
-\def\bse{\begin{subequations}}%
-\def\ese{\end{subequations}}%
-\def\nonu{\nonumber}%
-\def\psibar{\overline{\psi}} %
-\def\Delslash{\partial\!\!\!\!\!/}%
-\def\Gslash{G\!\!\!\!\!/}%
-\def\Lmbdslash{\lambda\!\!\!\!\!/}%
-\def\Jslash{J\!\!\!\!\!/}%
-\def\pslash{p\!\!\!\!/}%
-\def\qslash{q\!\!\!\!/}%
-\def\kslash{k\!\!\!\!/}%
-\def\[{\left[}
-\def\]{\right]}
-\def\({\left(}
-\def\){\right)}
+% \def\be{\begin{equation}} %
+% \def\ee{\end{equation}}%
+% \def\beq{\begin{eqnarray}}%
+% \def\eeq{\end{eqnarray}}%
+% \def\bse{\begin{subequations}}%
+% \def\ese{\end{subequations}}%
+% \def\nonu{\nonumber}%
+% \def\psibar{\overline{\psi}} %
+% \def\Delslash{\partial\!\!\!\!\!/}%
+% \def\Gslash{G\!\!\!\!\!/}%
+% \def\Lmbdslash{\lambda\!\!\!\!\!/}%
+% \def\Jslash{J\!\!\!\!\!/}%
+% \def\pslash{p\!\!\!\!/}%
+% \def\qslash{q\!\!\!\!/}%
+% \def\kslash{k\!\!\!\!/}%
+% \def\[{\left[}
+% \def\]{\right]}
+% \def\({\left(}
+% \def\){\right)}
 
-\def\Lag{{\cal L}}    % 
-\def\D{{\cal D}}      % 
-\def\H{{\cal H}}      % 
-\def\Z{{\cal Z}}      % 
-\def\S{{\textbf{S}}}  % 
-\def\d{{\rm d}}%
-\def\dt{{\rm{dt}}}%
-\def\Tr{{\rm{Tr}}}%
-\def\gm{\gamma^{\mu}}
-\def\ga{\gamma^{\alpha}}
-\def\gb{\gamma^{\beta}}
-\def\gn{\gamma^{\nu}}
-\def\gs{\gamma^{\sigma}}
-\def\gl{\gamma^{\lambda}}
-\def\gr{\gamma^{\rho}}
-\def\gd{\gamma^{\delta}}
+% \def\Lag{{\cal L}}    % 
+% \def\D{{\cal D}}      % 
+% \def\H{{\cal H}}      % 
+% \def\Z{{\cal Z}}      % 
+% \def\S{{\textbf{S}}}  % 
+% \def\d{{\rm d}}%
+% \def\dt{{\rm{dt}}}%
+% \def\Tr{{\rm{Tr}}}%
+% \def\gm{\gamma^{\mu}}
+% \def\ga{\gamma^{\alpha}}
+% \def\gb{\gamma^{\beta}}
+% \def\gn{\gamma^{\nu}}
+% \def\gs{\gamma^{\sigma}}
+% \def\gl{\gamma^{\lambda}}
+% \def\gr{\gamma^{\rho}}
+% \def\gd{\gamma^{\delta}}


### PR DESCRIPTION
## Math Bug

* Original ITU template def.tex file redefines the math display enviroment  \[  \] , which results an error when Greek symbols are used.  These redefined symbols are commented in the def.tex file.